### PR TITLE
fix "from_buffer_copy" byte values format

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,13 @@ Converts between Microchip's an575 float format and IEEE-754.
 ```python
 from pyAN575.__init__ import An575Float, Ieee754Float
 
-an_from_float = An575Float.from_float(3.141592618)
-print(float(an_from_float) == 3.141592618) # True
+an_from_float = An575Float.from_float(3.1415927410125732)
+print(float(an_from_float) == 3.1415927410125732) # True
 
-raw_an = An575Float.from_buffer_copy(b'850beb2a')
+raw_an = An575Float.from_buffer_copy(bytes.fromhex('850beb2a'))
+print(float(raw_an) == 69.95930480957031) # True
+
+raw_an = An575Float.from_buffer_copy(b'\x85\x0b\xeb\x2a')
 print(float(raw_an) == 69.95930480957031) # True
 ```
 


### PR DESCRIPTION
Hi Rony.

Thank you very much for sharing your work.

I have tried to use this module, but usage example doesn't work correctly.
The problem seems to be in the "_from_buffer_copy_" method inherited from the "_BigEndianStructure_" class, which expects a bytes object as hex, not as str.

I make this pull request in case you consider it appropriate to modify it.

Anyway, I have made an alternate, simpler raw implementation.
https://github.com/latchdevel/AN575

I hope you find it useful.
Best regards.
Jorge Rivera.

